### PR TITLE
Fix ignoreString

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -164,6 +164,7 @@ program.command("collect").action(async () => {
     const ignoreString = await text({
       message: `Are there any internal company dependencies we should ignore in the list. This are usually private packages in company scope. If not, leave the string empty.`,
       placeholder: `@${ghOrgName}`,
+      initialValue:`@${ghOrgName}`
     });
     const ignoreStringParsed = checkForEarlyExit(ignoreString);
 


### PR DESCRIPTION
If the user does not enter an organizaition to the it seems that the [`text`](https://github.com/natemoo-re/clack/tree/main/packages/prompts#text) method from [@clack/prompts](https://github.com/natemoo-re/clack/tree/main/packages/prompts#text) does not use the placeholder as a return value.

This PR should fix it.
